### PR TITLE
`tab_navigation` example update

### DIFF
--- a/crates/bevy_input_focus/src/tab_navigation.rs
+++ b/crates/bevy_input_focus/src/tab_navigation.rs
@@ -231,6 +231,8 @@ impl TabNavigation<'_, '_> {
                     for child in children.iter() {
                         self.gather_focusable(&mut focusable, *child);
                     }
+                    // Stable sort by tabindex
+                    focusable.sort_by_key(|(_, idx)| *idx);
                 }
             }
             _ => {
@@ -246,7 +248,11 @@ impl TabNavigation<'_, '_> {
 
                 // Search group descendants
                 tab_groups.iter().for_each(|(tg_entity, _)| {
-                    self.gather_focusable(&mut focusable, *tg_entity);
+                    // Maintain group sort order before TabIndex sort order
+                    let mut focusable_group: Vec<(Entity, TabIndex)> = Vec::new();
+                    self.gather_focusable(&mut focusable_group, *tg_entity);
+                    focusable_group.sort_by_key(|(_, idx)| *idx);
+                    focusable.append(&mut focusable_group);
                 });
             }
         }

--- a/examples/ui/tab_navigation.rs
+++ b/examples/ui/tab_navigation.rs
@@ -40,17 +40,14 @@ fn button_system(
         let mut text = text_query.get_mut(children[0]).unwrap();
         match *interaction {
             Interaction::Pressed => {
-                **text = "Press".to_string();
                 *color = PRESSED_BUTTON.into();
                 border_color.0 = RED.into();
             }
             Interaction::Hovered => {
-                **text = "Hover".to_string();
                 *color = HOVERED_BUTTON.into();
                 border_color.0 = Color::WHITE;
             }
             Interaction::None => {
-                **text = "Button".to_string();
                 *color = NORMAL_BUTTON.into();
                 border_color.0 = Color::BLACK;
             }
@@ -176,7 +173,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     TabGroup::modal(),
                 ))
                 .with_children(|parent| {
-                    for i in 0..4 {
+                    // Navigate these tabs in an arbitrary order.
+                    for i in [0, 3, 1, 2] {
                         create_button(parent, &asset_server, i);
                     }
                 });
@@ -209,7 +207,7 @@ fn create_button(parent: &mut ChildSpawnerCommands<'_>, asset_server: &AssetServ
             },
         )
         .with_child((
-            Text::new("Button"),
+            Text::new(format!("Button {index}")),
             TextFont {
                 font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                 font_size: 23.0,

--- a/examples/ui/tab_navigation.rs
+++ b/examples/ui/tab_navigation.rs
@@ -114,7 +114,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     TabGroup::new(0),
                 ))
                 .with_children(|parent| {
-                    // These tabs all have the same index, so they will be navigated according to their order as children.
+                    // These buttons all have the same `TabIndex`, so they will be navigated according to their order as children.
                     for _ in 0..4 {
                         create_button(parent, &asset_server, 0);
                     }

--- a/examples/ui/tab_navigation.rs
+++ b/examples/ui/tab_navigation.rs
@@ -34,10 +34,8 @@ fn button_system(
         ),
         (Changed<Interaction>, With<Button>),
     >,
-    mut text_query: Query<&mut Text>,
 ) {
     for (interaction, mut color, mut border_color, children) in &mut interaction_query {
-        let mut text = text_query.get_mut(children[0]).unwrap();
         match *interaction {
             Interaction::Pressed => {
                 *color = PRESSED_BUTTON.into();

--- a/examples/ui/tab_navigation.rs
+++ b/examples/ui/tab_navigation.rs
@@ -26,16 +26,11 @@ const PRESSED_BUTTON: Color = Color::srgb(0.35, 0.75, 0.35);
 
 fn button_system(
     mut interaction_query: Query<
-        (
-            &Interaction,
-            &mut BackgroundColor,
-            &mut BorderColor,
-            &Children,
-        ),
+        (&Interaction, &mut BackgroundColor, &mut BorderColor),
         (Changed<Interaction>, With<Button>),
     >,
 ) {
-    for (interaction, mut color, mut border_color, children) in &mut interaction_query {
+    for (interaction, mut color, mut border_color) in &mut interaction_query {
         match *interaction {
             Interaction::Pressed => {
                 *color = PRESSED_BUTTON.into();

--- a/examples/ui/tab_navigation.rs
+++ b/examples/ui/tab_navigation.rs
@@ -114,8 +114,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     TabGroup::new(0),
                 ))
                 .with_children(|parent| {
-                    for i in 0..4 {
-                        create_button(parent, &asset_server, i);
+                    // These tabs all have the same index, so they will be navigated according to their order as children.
+                    for _ in 0..4 {
+                        create_button(parent, &asset_server, 0);
                     }
                 });
 
@@ -135,7 +136,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     TabGroup::new(2),
                 ))
                 .with_children(|parent| {
-                    for i in 0..4 {
+                    // The orders of the `TabIndex`s is the reverse of the order of the buttons, so the buttons will be navigated in right-to-left order.
+                    for i in (0..4).rev() {
                         create_button(parent, &asset_server, i);
                     }
                 });
@@ -156,6 +158,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     TabGroup::new(1),
                 ))
                 .with_children(|parent| {
+                    // The order of the `TabIndex`s matches the order of the buttons, so the buttons will be navigated in left-to-right order.
                     for i in 0..4 {
                         create_button(parent, &asset_server, i);
                     }

--- a/examples/ui/tab_navigation.rs
+++ b/examples/ui/tab_navigation.rs
@@ -114,10 +114,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     TabGroup::new(0),
                 ))
                 .with_children(|parent| {
-                    create_button(parent, &asset_server);
-                    create_button(parent, &asset_server);
-                    create_button(parent, &asset_server);
-                    create_button(parent, &asset_server);
+                    for i in 0..4 {
+                        create_button(parent, &asset_server, i);
+                    }
                 });
 
             parent.spawn(Text::new("Tab Group 2"));
@@ -136,10 +135,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     TabGroup::new(2),
                 ))
                 .with_children(|parent| {
-                    create_button(parent, &asset_server);
-                    create_button(parent, &asset_server);
-                    create_button(parent, &asset_server);
-                    create_button(parent, &asset_server);
+                    for i in 0..4 {
+                        create_button(parent, &asset_server, i);
+                    }
                 });
 
             parent.spawn(Text::new("Tab Group 1"));
@@ -158,10 +156,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     TabGroup::new(1),
                 ))
                 .with_children(|parent| {
-                    create_button(parent, &asset_server);
-                    create_button(parent, &asset_server);
-                    create_button(parent, &asset_server);
-                    create_button(parent, &asset_server);
+                    for i in 0..4 {
+                        create_button(parent, &asset_server, i);
+                    }
                 });
 
             parent.spawn(Text::new("Modal Tab Group"));
@@ -176,15 +173,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     TabGroup::modal(),
                 ))
                 .with_children(|parent| {
-                    create_button(parent, &asset_server);
-                    create_button(parent, &asset_server);
-                    create_button(parent, &asset_server);
-                    create_button(parent, &asset_server);
+                    for i in 0..4 {
+                        create_button(parent, &asset_server, i);
+                    }
                 });
         });
 }
 
-fn create_button(parent: &mut ChildSpawnerCommands<'_>, asset_server: &AssetServer) {
+fn create_button(parent: &mut ChildSpawnerCommands<'_>, asset_server: &AssetServer, index: i32) {
     parent
         .spawn((
             Button,
@@ -201,7 +197,7 @@ fn create_button(parent: &mut ChildSpawnerCommands<'_>, asset_server: &AssetServ
             BorderColor(Color::BLACK),
             BorderRadius::MAX,
             BackgroundColor(NORMAL_BUTTON),
-            TabIndex(0),
+            TabIndex(index),
         ))
         .observe(
             |mut trigger: Trigger<Pointer<Click>>, mut focus: ResMut<InputFocus>| {

--- a/examples/ui/tab_navigation.rs
+++ b/examples/ui/tab_navigation.rs
@@ -174,7 +174,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 ))
                 .with_children(|parent| {
                     // Navigate these tabs in an arbitrary order.
-                    for i in [0, 3, 1, 2] {
+                    for i in [0, 2, 3, 1] {
                         create_button(parent, &asset_server, i);
                     }
                 });
@@ -186,7 +186,7 @@ fn create_button(parent: &mut ChildSpawnerCommands<'_>, asset_server: &AssetServ
         .spawn((
             Button,
             Node {
-                width: Val::Px(150.0),
+                width: Val::Px(160.0),
                 height: Val::Px(65.0),
                 border: UiRect::all(Val::Px(5.0)),
                 // horizontally center child text
@@ -207,7 +207,7 @@ fn create_button(parent: &mut ChildSpawnerCommands<'_>, asset_server: &AssetServ
             },
         )
         .with_child((
-            Text::new(format!("Button {index}")),
+            Text::new(format!("TabIndex {index}")),
             TextFont {
                 font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                 font_size: 23.0,


### PR DESCRIPTION
Changes the `tab_navigation` example so that instead of using `TabIndex(0)` for all the tabs it uses a range of `TabIndex` values for the tabs in each group and and reverses the order of the `TabIndex`s for group 2 so the tab navigation path goes in a winding snake pattern.